### PR TITLE
自動更新の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,4 @@
 $(function(){
-  var last_message_id = $('.message:last').data("message-id");
-  console.log(last_message_id);
       function buildHTML(message){
         if ( message.image ) {
           var html =
@@ -62,4 +60,29 @@ $('#new_message').on('submit', function(e){
         alert("メッセージ送信に失敗しました");
       });
 })
+  var reloadMessages = function() {
+    var last_message_id = $('.message-posts:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });


### PR DESCRIPTION
# why
いちいちリロードしなくても相手からのメッセージが表示されるようになり、快適にチャットができるようにするため
# what
メッセージごとにidを取得できるようにする
新しいメッセージidをリクエストとして送る
コントローラーでアクション作って↑のidよりも大きいidのメッセージたちをレスポンスする
レスポンスされたメッセージをメッセージ一覧の最後に追加する